### PR TITLE
Fix: Ensure networkConfig is populated in backend payload

### DIFF
--- a/app/app/network-editor/components/NetworkEditor.tsx
+++ b/app/app/network-editor/components/NetworkEditor.tsx
@@ -148,9 +148,10 @@ const NetworkEditor = forwardRef<NetworkEditorRef, NetworkEditorProps>(({ onConf
     }
   }));
 
-  const loadInitialNetwork = useCallback(() => {
+  ///////
+  useEffect(() => {
     if (!reactFlowInstance) return;
-
+  
     const savedFlowString = localStorage.getItem('gh2-network');
     if (savedFlowString) {
       try {
@@ -174,7 +175,7 @@ const NetworkEditor = forwardRef<NetworkEditorRef, NetworkEditorProps>(({ onConf
         toast.error("Failed to load network from local storage due to invalid format.");
       }
     }
-
+  
     // If no valid saved data, load default
     setNodes(defaultReactFlowState.nodes);
     setEdges(defaultReactFlowState.edges);
@@ -184,13 +185,8 @@ const NetworkEditor = forwardRef<NetworkEditorRef, NetworkEditorProps>(({ onConf
     if (onConfigChange) {
       onConfigChange(defaultReactFlowState);
     }
-  }, [reactFlowInstance, setNodes, setEdges, onConfigChange]);
-  
-  useEffect(() => {
-    if (reactFlowInstance) {
-      loadInitialNetwork();
-    }
-  }, [reactFlowInstance, loadInitialNetwork]);
+  }, [reactFlowInstance]);
+  //////
 
   const onConnect = useCallback(
     (connection: Connection) => {

--- a/app/app/network-editor/components/NetworkEditor.tsx
+++ b/app/app/network-editor/components/NetworkEditor.tsx
@@ -20,6 +20,21 @@ import 'reactflow/dist/style.css';
 import '../styles/editor.css';
 import { toast } from 'react-toastify';
 
+export const getPortColor = (dataType: string): string => {
+  switch (dataType) {
+    case 'power':
+      return '#ff9800';
+    case 'hydrogen':
+      return '#2196f3';
+    case 'oxygen':
+      return '#4caf50';
+    case 'percentage':
+      return '#9c27b0';
+    default:
+      return '#555';
+  }
+};
+
 const ModuleNode = dynamic(() => import('./ModuleNode'), { ssr: false });
 const ModuleSidebar = dynamic(() => import('./ModuleSidebar'), { ssr: false });
 const PropertiesPanel = dynamic(() => import('./PropertiesPanel'), { ssr: false });
@@ -38,7 +53,7 @@ export interface NetworkEditorRef {
   getCurrentFlow: () => any | null;
 }
 
-const defaultReactFlowState = {
+const defaultReactFlowState: { nodes: Node<any>[]; edges: Edge<any>[]; viewport: { x: number; y: number; zoom: number } } = {
   nodes: [
     {
       id: "renewable_energy-1",
@@ -401,21 +416,5 @@ const NetworkEditor = forwardRef<NetworkEditorRef, NetworkEditorProps>(({ onConf
 
 // Add display name for better debugging in React DevTools
 NetworkEditor.displayName = 'NetworkEditor';
-
-// getPortColor function remains unchanged
-export const getPortColor = (dataType: string): string => {
-  switch (dataType) {
-    case 'power':
-      return '#ff9800';
-    case 'hydrogen':
-      return '#2196f3';
-    case 'oxygen':
-      return '#4caf50';
-    case 'percentage':
-      return '#9c27b0';
-    default:
-      return '#555';
-  }
-};
 
 export default NetworkEditor;

--- a/app/app/network-editor/components/NetworkEditor.tsx
+++ b/app/app/network-editor/components/NetworkEditor.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback, forwardRef, useImperativeHandle } from 'react';
 import dynamic from 'next/dynamic';
 import ReactFlow, {
   ReactFlowProvider,
@@ -33,12 +33,25 @@ interface NetworkEditorProps {
   onConfigChange?: (config: any) => void;
 }
 
-const NetworkEditor: React.FC<NetworkEditorProps> = ({ onConfigChange }) => {
+export interface NetworkEditorRef {
+  getCurrentFlow: () => any | null;
+}
+
+const NetworkEditor = forwardRef<NetworkEditorRef, NetworkEditorProps>(({ onConfigChange }, ref) => {
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
   const [reactFlowInstance, setReactFlowInstance] = useState<any>(null);
   const [selectedElement, setSelectedElement] = useState<Node | Edge | null>(null);
+
+  useImperativeHandle(ref, () => ({
+    getCurrentFlow: () => {
+      if (reactFlowInstance) {
+        return reactFlowInstance.toObject();
+      }
+      return null;
+    }
+  }));
 
   const onConnect = useCallback(
     (connection: Connection) => {
@@ -230,7 +243,10 @@ const NetworkEditor: React.FC<NetworkEditorProps> = ({ onConfigChange }) => {
       />
     </div>
   );
-};
+});
+
+// Add display name for better debugging in React DevTools
+NetworkEditor.displayName = 'NetworkEditor';
 
 export const getPortColor = (dataType: string): string => {
   switch (dataType) {

--- a/app/app/network-editor/data/moduleDefinitions.ts
+++ b/app/app/network-editor/data/moduleDefinitions.ts
@@ -28,21 +28,24 @@ export const moduleDefinitions = {
         name: 'PV Power',
         dataType: 'power',
         unit: 'MW',
-        description: 'Solar power generation'
+        description: 'Solar power generation',
+        isRequired: false
       },
       {
         id: 'wind_power',
         name: 'Wind Power',
         dataType: 'power',
         unit: 'MW',
-        description: 'Wind power generation'
+        description: 'Wind power generation',
+        isRequired: false
       },
       {
         id: 'total_power',
         name: 'Total Power',
         dataType: 'power',
         unit: 'MW',
-        description: 'Combined power generation'
+        description: 'Combined power generation',
+        isRequired: false
       }
     ],
     parameters: {
@@ -64,14 +67,16 @@ export const moduleDefinitions = {
         name: 'Charge Power',
         dataType: 'power',
         unit: 'MW',
-        description: 'Power input for charging'
+        description: 'Power input for charging',
+        isRequired: true
       },
       {
         id: 'discharge_request',
         name: 'Discharge Request',
         dataType: 'power',
         unit: 'MW',
-        description: 'Requested power output'
+        description: 'Requested power output',
+        isRequired: true
       }
     ],
     outputPorts: [
@@ -80,28 +85,32 @@ export const moduleDefinitions = {
         name: 'Available Power',
         dataType: 'power',
         unit: 'MW',
-        description: 'Power available for discharge'
+        description: 'Power available for discharge',
+        isRequired: false
       },
       {
         id: 'actual_discharge',
         name: 'Actual Discharge',
         dataType: 'power',
         unit: 'MW',
-        description: 'Actual power discharged'
+        description: 'Actual power discharged',
+        isRequired: false
       },
       {
         id: 'power_shortfall',
         name: 'Power Shortfall',
         dataType: 'power',
         unit: 'MW',
-        description: 'Shortfall in requested power'
+        description: 'Shortfall in requested power',
+        isRequired: false
       },
       {
         id: 'soc',
         name: 'State of Charge',
         dataType: 'percentage',
         unit: '%',
-        description: 'Current battery state of charge'
+        description: 'Current battery state of charge',
+        isRequired: false
       }
     ],
     parameters: {
@@ -125,7 +134,8 @@ export const moduleDefinitions = {
         name: 'Power Input',
         dataType: 'power',
         unit: 'MW',
-        description: 'Power input for hydrogen production'
+        description: 'Power input for hydrogen production',
+        isRequired: true
       }
     ],
     outputPorts: [
@@ -134,28 +144,32 @@ export const moduleDefinitions = {
         name: 'H₂ Output',
         dataType: 'hydrogen',
         unit: 'NM³/h',
-        description: 'Hydrogen production rate'
+        description: 'Hydrogen production rate',
+        isRequired: false
       },
       {
         id: 'o2_output',
         name: 'O₂ Output',
         dataType: 'oxygen',
         unit: 'NM³/h',
-        description: 'Oxygen production rate'
+        description: 'Oxygen production rate',
+        isRequired: false
       },
       {
         id: 'power_consumed',
         name: 'Power Consumed',
         dataType: 'power',
         unit: 'MW',
-        description: 'Actual power consumed'
+        description: 'Actual power consumed',
+        isRequired: false
       },
       {
         id: 'efficiency',
         name: 'Efficiency',
         dataType: 'percentage',
         unit: '%',
-        description: 'Current operating efficiency'
+        description: 'Current operating efficiency',
+        isRequired: false
       }
     ],
     parameters: {
@@ -178,14 +192,16 @@ export const moduleDefinitions = {
         name: 'H₂ Input',
         dataType: 'hydrogen',
         unit: 'NM³/h',
-        description: 'Hydrogen input flow rate'
+        description: 'Hydrogen input flow rate',
+        isRequired: true
       },
       {
         id: 'h2_output_request',
         name: 'H₂ Output Request',
         dataType: 'hydrogen',
         unit: 'NM³/h',
-        description: 'Requested hydrogen output flow rate'
+        description: 'Requested hydrogen output flow rate',
+        isRequired: true
       }
     ],
     outputPorts: [
@@ -194,28 +210,32 @@ export const moduleDefinitions = {
         name: 'H₂ Output',
         dataType: 'hydrogen',
         unit: 'NM³/h',
-        description: 'Actual hydrogen output flow rate'
+        description: 'Actual hydrogen output flow rate',
+        isRequired: false
       },
       {
         id: 'h2_excess',
         name: 'H₂ Excess',
         dataType: 'hydrogen',
         unit: 'NM³/h',
-        description: 'Excess hydrogen that could not be stored'
+        description: 'Excess hydrogen that could not be stored',
+        isRequired: false
       },
       {
         id: 'h2_shortfall',
         name: 'H₂ Shortfall',
         dataType: 'hydrogen',
         unit: 'NM³/h',
-        description: 'Hydrogen shortfall that could not be supplied'
+        description: 'Hydrogen shortfall that could not be supplied',
+        isRequired: false
       },
       {
         id: 'soc',
         name: 'State of Charge',
         dataType: 'percentage',
         unit: '%',
-        description: 'Current state of charge'
+        description: 'Current state of charge',
+        isRequired: false
       }
     ],
     parameters: {
@@ -239,14 +259,16 @@ export const moduleDefinitions = {
         name: 'O₂ Input',
         dataType: 'oxygen',
         unit: 'NM³/h',
-        description: 'Oxygen input flow rate'
+        description: 'Oxygen input flow rate',
+        isRequired: true
       },
       {
         id: 'o2_output_request',
         name: 'O₂ Output Request',
         dataType: 'oxygen',
         unit: 'NM³/h',
-        description: 'Requested oxygen output flow rate'
+        description: 'Requested oxygen output flow rate',
+        isRequired: true
       }
     ],
     outputPorts: [
@@ -255,28 +277,32 @@ export const moduleDefinitions = {
         name: 'O₂ Output',
         dataType: 'oxygen',
         unit: 'NM³/h',
-        description: 'Actual oxygen output flow rate'
+        description: 'Actual oxygen output flow rate',
+        isRequired: false
       },
       {
         id: 'o2_vented',
         name: 'O₂ Vented',
         dataType: 'oxygen',
         unit: 'NM³/h',
-        description: 'Oxygen vented to atmosphere'
+        description: 'Oxygen vented to atmosphere',
+        isRequired: false
       },
       {
         id: 'o2_shortfall',
         name: 'O₂ Shortfall',
         dataType: 'oxygen',
         unit: 'NM³/h',
-        description: 'Oxygen shortfall that could not be supplied'
+        description: 'Oxygen shortfall that could not be supplied',
+        isRequired: false
       },
       {
         id: 'soc',
         name: 'State of Charge',
         dataType: 'percentage',
         unit: '%',
-        description: 'Current state of charge'
+        description: 'Current state of charge',
+        isRequired: false
       }
     ],
     parameters: {
@@ -301,14 +327,16 @@ export const moduleDefinitions = {
         name: 'Power Request',
         dataType: 'power',
         unit: 'MW',
-        description: 'Requested power from grid'
+        description: 'Requested power from grid',
+        isRequired: true
       },
       {
         id: 'power_export',
         name: 'Power Export',
         dataType: 'power',
         unit: 'MW',
-        description: 'Power to export to grid'
+        description: 'Power to export to grid',
+        isRequired: true
       }
     ],
     outputPorts: [
@@ -317,28 +345,32 @@ export const moduleDefinitions = {
         name: 'Power Imported',
         dataType: 'power',
         unit: 'MW',
-        description: 'Actual power imported from grid'
+        description: 'Actual power imported from grid',
+        isRequired: false
       },
       {
         id: 'power_exported',
         name: 'Power Exported',
         dataType: 'power',
         unit: 'MW',
-        description: 'Actual power exported to grid'
+        description: 'Actual power exported to grid',
+        isRequired: false
       },
       {
         id: 'import_cost',
         name: 'Import Cost',
         dataType: 'cost',
         unit: 'currency/h',
-        description: 'Cost of imported power'
+        description: 'Cost of imported power',
+        isRequired: false
       },
       {
         id: 'export_revenue',
         name: 'Export Revenue',
         dataType: 'cost',
         unit: 'currency/h',
-        description: 'Revenue from exported power'
+        description: 'Revenue from exported power',
+        isRequired: false
       }
     ],
     parameters: {
@@ -360,14 +392,16 @@ export const moduleDefinitions = {
         name: 'H₂ Available',
         dataType: 'hydrogen',
         unit: 'NM³/h',
-        description: 'Available hydrogen for delivery'
+        description: 'Available hydrogen for delivery',
+        isRequired: true
       },
       {
         id: 'o2_available',
         name: 'O₂ Available',
         dataType: 'oxygen',
         unit: 'NM³/h',
-        description: 'Available oxygen for delivery'
+        description: 'Available oxygen for delivery',
+        isRequired: true
       }
     ],
     outputPorts: [
@@ -376,35 +410,40 @@ export const moduleDefinitions = {
         name: 'H₂ Delivered',
         dataType: 'hydrogen',
         unit: 'NM³/h',
-        description: 'Hydrogen delivered to clients'
+        description: 'Hydrogen delivered to clients',
+        isRequired: false
       },
       {
         id: 'o2_delivered',
         name: 'O₂ Delivered',
         dataType: 'oxygen',
         unit: 'NM³/h',
-        description: 'Oxygen delivered to clients'
+        description: 'Oxygen delivered to clients',
+        isRequired: false
       },
       {
         id: 'h2_revenue',
         name: 'H₂ Revenue',
         dataType: 'cost',
         unit: 'currency/h',
-        description: 'Revenue from hydrogen sales'
+        description: 'Revenue from hydrogen sales',
+        isRequired: false
       },
       {
         id: 'o2_revenue',
         name: 'O₂ Revenue',
         dataType: 'cost',
         unit: 'currency/h',
-        description: 'Revenue from oxygen sales'
+        description: 'Revenue from oxygen sales',
+        isRequired: false
       },
       {
         id: 'net_revenue',
         name: 'Net Revenue',
         dataType: 'cost',
         unit: 'currency/h',
-        description: 'Total revenue from all sales'
+        description: 'Total revenue from all sales',
+        isRequired: false
       }
     ],
     parameters: {

--- a/app/app/network-editor/data/networkConfig.ts
+++ b/app/app/network-editor/data/networkConfig.ts
@@ -1,0 +1,124 @@
+{
+  "nodes": [
+    {
+      "id": "renewable_energy-1",
+      "type": "moduleNode",
+      "position": { "x": 50, "y": 50 },
+      "data": {
+        "id": "renewable_energy-1",
+        "label": "Renewable Energy 1",
+        "type": "renewable_energy",
+        "description": "Solar and wind power generation",
+        "inputPorts": [
+          { "id": "latitude", "name": "Latitude", "dataType": "location", "unit": "degrees", "description": "Site latitude", "isRequired": true },
+          { "id": "longitude", "name": "Longitude", "dataType": "location", "unit": "degrees", "description": "Site longitude", "isRequired": true }
+        ],
+        "outputPorts": [
+          { "id": "pv_power", "name": "PV Power", "dataType": "power", "unit": "MW", "description": "Solar power generation" },
+          { "id": "wind_power", "name": "Wind Power", "dataType": "power", "unit": "MW", "description": "Wind power generation" },
+          { "id": "total_power", "name": "Total Power", "dataType": "power", "unit": "MW", "description": "Combined power generation" }
+        ],
+        "parameters": { "pv_capacity_mw": 10.0, "wind_capacity_mw": 5.0, "use_api": true, "pv_efficiency": 0.85, "wind_efficiency": 0.9 }
+      }
+    },
+    {
+      "id": "electrolyzer-1",
+      "type": "moduleNode",
+      "position": { "x": 300, "y": 50 },
+      "data": {
+        "id": "electrolyzer-1",
+        "label": "Electrolyzer 1",
+        "type": "electrolyzer",
+        "description": "Hydrogen production system",
+        "inputPorts": [
+          { "id": "power_input", "name": "Power Input", "dataType": "power", "unit": "MW", "description": "Power input for hydrogen production" }
+        ],
+        "outputPorts": [
+          { "id": "h2_output", "name": "H₂ Output", "dataType": "hydrogen", "unit": "NM³/h", "description": "Hydrogen production rate" },
+          { "id": "o2_output", "name": "O₂ Output", "dataType": "oxygen", "unit": "NM³/h", "description": "Oxygen production rate" },
+          { "id": "power_consumed", "name": "Power Consumed", "dataType": "power", "unit": "MW", "description": "Actual power consumed" },
+          { "id": "efficiency", "name": "Efficiency", "dataType": "percentage", "unit": "%", "description": "Current operating efficiency" }
+        ],
+        "parameters": { "capacity_mw": 8.0, "min_load_percentage": 0.2, "max_load_percentage": 1.0, "base_efficiency": 0.7, "h2_production_rate_nm3_per_mwh": 210.0, "o2_production_rate_nm3_per_mwh": 105.0 }
+      }
+    },
+    {
+      "id": "hydrogen_storage-1",
+      "type": "moduleNode",
+      "position": { "x": 550, "y": 50 },
+      "data": {
+        "id": "hydrogen_storage-1",
+        "label": "Hydrogen Storage 1",
+        "type": "hydrogen_storage",
+        "description": "Hydrogen storage system",
+        "inputPorts": [
+          { "id": "h2_input", "name": "H₂ Input", "dataType": "hydrogen", "unit": "NM³/h", "description": "Hydrogen input flow rate" },
+          { "id": "h2_output_request", "name": "H₂ Output Request", "dataType": "hydrogen", "unit": "NM³/h", "description": "Requested hydrogen output flow rate" }
+        ],
+        "outputPorts": [
+          { "id": "h2_output", "name": "H₂ Output", "dataType": "hydrogen", "unit": "NM³/h", "description": "Actual hydrogen output flow rate" },
+          { "id": "h2_excess", "name": "H₂ Excess", "dataType": "hydrogen", "unit": "NM³/h", "description": "Excess hydrogen that could not be stored" },
+          { "id": "h2_shortfall", "name": "H₂ Shortfall", "dataType": "hydrogen", "unit": "NM³/h", "description": "Hydrogen shortfall that could not be supplied" },
+          { "id": "soc", "name": "State of Charge", "dataType": "percentage", "unit": "%", "description": "Current state of charge" }
+        ],
+        "parameters": { "capacity_nm3": 10000.0, "initial_soc": 0.2, "min_soc": 0.05, "max_soc": 0.95, "max_fill_rate_nm3_per_hour": 200.0, "max_empty_rate_nm3_per_hour": 200.0, "leakage_rate": 0.001 }
+      }
+    },
+    {
+      "id": "client_delivery-1",
+      "type": "moduleNode",
+      "position": { "x": 800, "y": 50 },
+      "data": {
+        "id": "client_delivery-1",
+        "label": "Client Delivery 1",
+        "type": "client_delivery",
+        "description": "Client delivery management",
+        "inputPorts": [
+          { "id": "h2_available", "name": "H₂ Available", "dataType": "hydrogen", "unit": "NM³/h", "description": "Available hydrogen for delivery" },
+          { "id": "o2_available", "name": "O₂ Available", "dataType": "oxygen", "unit": "NM³/h", "description": "Available oxygen for delivery" }
+        ],
+        "outputPorts": [
+          { "id": "h2_delivered", "name": "H₂ Delivered", "dataType": "hydrogen", "unit": "NM³/h", "description": "Hydrogen delivered to clients" },
+          { "id": "o2_delivered", "name": "O₂ Delivered", "dataType": "oxygen", "unit": "NM³/h", "description": "Oxygen delivered to clients" },
+          { "id": "h2_revenue", "name": "H₂ Revenue", "dataType": "cost", "unit": "currency/h", "description": "Revenue from hydrogen sales" },
+          { "id": "o2_revenue", "name": "O₂ Revenue", "dataType": "cost", "unit": "currency/h", "description": "Revenue from oxygen sales" },
+          { "id": "net_revenue", "name": "Net Revenue", "dataType": "cost", "unit": "currency/h", "description": "Total revenue from all sales" }
+        ],
+        "parameters": { "h2_contract_rate": 50.0, "h2_contract_price": 3.5, "o2_contract_rate": 25.0, "o2_contract_price": 0.8, "h2_spot_price": 2.8, "o2_spot_price": 0.5, "delivery_cost_per_nm3": 0.1 }
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "e-renewable_energy-1-total_power-electrolyzer-1-power_input",
+      "source": "renewable_energy-1",
+      "target": "electrolyzer-1",
+      "sourceHandle": "output-total_power",
+      "targetHandle": "input-power_input",
+      "data": { "sourcePortId": "total_power", "targetPortId": "power_input", "dataType": "power" },
+      "animated": true,
+      "style": { "stroke": "#ff9800" }
+    },
+    {
+      "id": "e-electrolyzer-1-h2_output-hydrogen_storage-1-h2_input",
+      "source": "electrolyzer-1",
+      "target": "hydrogen_storage-1",
+      "sourceHandle": "output-h2_output",
+      "targetHandle": "input-h2_input",
+      "data": { "sourcePortId": "h2_output", "targetPortId": "h2_input", "dataType": "hydrogen" },
+      "animated": true,
+      "style": { "stroke": "#2196f3" }
+    },
+    {
+      "id": "e-hydrogen_storage-1-h2_output-client_delivery-1-h2_available",
+      "source": "hydrogen_storage-1",
+      "target": "client_delivery-1",
+      "sourceHandle": "output-h2_output",
+      "targetHandle": "input-h2_available",
+      "data": { "sourcePortId": "h2_output", "targetPortId": "h2_available", "dataType": "hydrogen" },
+      "animated": true,
+      "style": { "stroke": "#2196f3" }
+    }
+  ],
+  "viewport": { "x": 0, "y": 0, "zoom": 1 }
+}

--- a/app/app/network-editor/data/networkConfig.ts
+++ b/app/app/network-editor/data/networkConfig.ts
@@ -1,4 +1,4 @@
-{
+export const networkConfig = {
   "nodes": [
     {
       "id": "renewable_energy-1",
@@ -121,4 +121,4 @@
     }
   ],
   "viewport": { "x": 0, "y": 0, "zoom": 1 }
-}
+};

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import { Inter, Outfit } from 'next/font/google'
 import './globals.css'
 import { ToastContainer } from "react-toastify"
 import "react-toastify/dist/ReactToastify.css"
+import ClientToastContainer from "@/components/ClientToastContainer"
 
 const inter = Inter({ 
   subsets: ['latin'],
@@ -27,18 +28,7 @@ export default function RootLayout({
     <html lang="en" className={`${inter.variable} ${outfit.variable}`}>
       <body className="font-sans antialiased">
         {children}
-        <ToastContainer
-          position="bottom-right"
-          autoClose={5000}
-          hideProgressBar={false}
-          newestOnTop={false}
-          closeOnClick
-          rtl={false}
-          pauseOnFocusLoss
-          draggable
-          pauseOnHover
-          theme="light"
-        />
+        <ClientToastContainer />
       </body>
     </html>
   )

--- a/components/ClientToastContainer.tsx
+++ b/components/ClientToastContainer.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+
+export default function ClientToastContainer() {
+  return (
+    <ToastContainer
+      position="bottom-right"
+      autoClose={5000}
+      hideProgressBar={false}
+      newestOnTop={false}
+      closeOnClick
+      rtl={false}
+      pauseOnFocusLoss
+      draggable
+      pauseOnHover
+      theme="light"
+    />
+  );
+}


### PR DESCRIPTION
I've modified NetworkEditor to expose its current state via a ref. The main page now calls this in its handler to fetch the latest network configuration from the editor before sending data to the backend.

This resolves an issue where networkConfig could be null if you did not explicitly save the network in the editor before submitting the main optimization form.